### PR TITLE
correct mistake in Prescaler for PC sampling

### DIFF
--- a/trace_example.c
+++ b/trace_example.c
@@ -49,7 +49,7 @@ void configure_tracing()
     
     /* Configure PC sampling and exception trace  */
     DWT->CTRL = (1 << DWT_CTRL_CYCTAP_Pos) // Prescaler for PC sampling
-                                           // 0 = x32, 1 = x512
+                                           // 0 = x64, 1 = x1024
               | (0 << DWT_CTRL_POSTPRESET_Pos) // Postscaler for PC sampling
                                                 // Divider = value + 1
               | (1 << DWT_CTRL_PCSAMPLENA_Pos) // Enable PC sampling


### PR DESCRIPTION
I think that when DWT_CTRL_CYCTAP_Pos is 0 the Prescaler for PC sampling should be 64 and when DWT_CTRL_CYCTAP_Pos is 1 the Prescaler for PC sampling should be 1024

ref:
https://interrupt.memfault.com/blog/profiling-firmware-on-cortex-m
TABLE TABLE11-7 OF ARM DDI 0337E
